### PR TITLE
Add spreadsheet controls and CSV import/export

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -17,6 +17,12 @@ source("group_comparisons.R")
 source("anova_assumptions.R")
 ```
 
+## Web Interface
+
+This project includes a lightweight browser interface in `index.html` that
+leverages WebR. You can import a CSV file or manually enter data into the
+embedded spreadsheet, then export the edited table if needed.
+
 # **Function: paired_comparison()**
 
 ## Purpose

--- a/index.html
+++ b/index.html
@@ -15,16 +15,30 @@
         pre { background-color: #f4f4f4; padding: 1em; white-space: pre-wrap; }
         button:disabled { cursor: not-allowed; background-color: #ccc; }
         /* Make the spreadsheet container look nice */
-        #spreadsheet-container { width: 100%; height: 300px; overflow: hidden; }
+        #spreadsheet-container {
+            width: 100%;
+            height: 300px;
+            overflow: hidden;
+            border: 1px solid #ddd;
+        }
+        #spreadsheet-container.dragover {
+            border-color: #3f51b5;
+            background-color: #f0f4ff;
+        }
     </style>
 </head>
 <body>
     <h1>WebR Statistics Analyzer</h1>
 
+    <p>Import a CSV file or manually edit the spreadsheet below.</p>
+
     <div class="controls">
-        <button id="load-csv-button">Load CSV File</button>
+        <button id="load-csv-button">Import CSV</button>
         <input type="file" id="csv-file-input" accept=".csv" style="display: none;">
         <button id="add-row-button">Add Row</button>
+        <button id="add-col-button">Add Column</button>
+        <button id="clear-table-button">Clear Table</button>
+        <button id="export-csv-button">Export CSV</button>
     </div>
 
     <div id="spreadsheet-container"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -5,6 +5,9 @@ const webR = new WebR();
 const fileInput = document.getElementById('csv-file-input');
 const loadCsvButton = document.getElementById('load-csv-button');
 const addRowButton = document.getElementById('add-row-button');
+const addColButton = document.getElementById('add-col-button');
+const clearTableButton = document.getElementById('clear-table-button');
+const exportCsvButton = document.getElementById('export-csv-button');
 const spreadsheetContainer = document.getElementById('spreadsheet-container');
 const beforeColSelect = document.getElementById('before-col-select');
 const afterColSelect = document.getElementById('after-col-select');
@@ -63,6 +66,24 @@ function updateColumnSelectors() {
     }, 0);
 }
 
+function loadCsvData(file) {
+    Papa.parse(file, {
+        header: true,
+        skipEmptyLines: true,
+        complete: function(results) {
+            const headers = results.meta.fields;
+            const tableData = results.data.map(row =>
+                headers.map(field => row[field] !== undefined ? row[field] : '')
+            );
+            hot.updateSettings({
+                colHeaders: headers,
+                data: tableData,
+                columns: headers.map(() => ({})),
+            });
+        }
+    });
+}
+
 async function main() {
     try {
         statusMessage.innerText = "Initializing WebR...";
@@ -98,25 +119,48 @@ async function main() {
     // Event listeners for spreadsheet controls
     loadCsvButton.addEventListener('click', () => { fileInput.click(); });
     addRowButton.addEventListener('click', () => { hot.alter('insert_row_below'); });
+    addColButton.addEventListener('click', () => {
+        const numCols = hot.countCols();
+        const newHeader = `Column ${String.fromCharCode(65 + numCols)}`;
+        hot.alter('insert_col', numCols);
+        const headers = hot.getColHeader();
+        headers[numCols] = newHeader;
+        hot.updateSettings({ colHeaders: headers });
+    });
+    clearTableButton.addEventListener('click', () => {
+        hot.loadData([["", ""]]);
+        hot.updateSettings({ colHeaders: ["Column A", "Column B"] });
+    });
+    exportCsvButton.addEventListener('click', () => {
+        const data = hot.getData();
+        const headers = hot.getColHeader();
+        const csv = Papa.unparse({ fields: headers, data: data }, { skipEmptyLines: false });
+        const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+        const link = document.createElement('a');
+        link.href = URL.createObjectURL(blob);
+        link.download = 'data.csv';
+        link.click();
+    });
 
     fileInput.addEventListener('change', (event) => {
         if (event.target.files.length > 0) {
-            Papa.parse(event.target.files[0], {
-                header: true,
-                skipEmptyLines: true,
-                complete: function(results) {
-                    const headers = results.meta.fields;
-                    const tableData = results.data.map(row => 
-                        headers.map(field => row[field] !== undefined ? row[field] : '')
-                    );
-                    hot.updateSettings({
-                        colHeaders: headers,
-                        data: tableData,
-                        columns: headers.map(() => ({})),
-                    });
-                }
-            });
+            loadCsvData(event.target.files[0]);
             fileInput.value = '';
+        }
+    });
+
+    spreadsheetContainer.addEventListener('dragover', (e) => {
+        e.preventDefault();
+        spreadsheetContainer.classList.add('dragover');
+    });
+    spreadsheetContainer.addEventListener('dragleave', () => {
+        spreadsheetContainer.classList.remove('dragover');
+    });
+    spreadsheetContainer.addEventListener('drop', (e) => {
+        e.preventDefault();
+        spreadsheetContainer.classList.remove('dragover');
+        if (e.dataTransfer.files.length > 0) {
+            loadCsvData(e.dataTransfer.files[0]);
         }
     });
 


### PR DESCRIPTION
## Summary
- add new buttons for column management, clearing, and exporting
- enable drag-and-drop CSV import and data export
- mention the web interface in the README

## Testing
- `R -q -e "1+1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860a56d950c832faaaf52563dc25212